### PR TITLE
Improve button focus visibility

### DIFF
--- a/grid-column-align.js
+++ b/grid-column-align.js
@@ -1,0 +1,28 @@
+let Declaration = require('../declaration')
+
+class GridColumnAlign extends Declaration {
+  /**
+   * Do not prefix flexbox values
+   */
+  check(decl) {
+    return !decl.value.includes('flex-') && decl.value !== 'baseline'
+  }
+
+  /**
+   * Change property name for IE
+   */
+  prefixed(prop, prefix) {
+    return prefix + 'grid-column-align'
+  }
+
+  /**
+   * Change IE property back
+   */
+  normalize() {
+    return 'justify-self'
+  }
+}
+
+GridColumnAlign.names = ['grid-column-align']
+
+module.exports = GridColumnAlign


### PR DESCRIPTION
Enhance keyboard accessibility by updating button focus styles to use :focus-visible and a higher-contrast outline. Adjusted outline color and outline-offset and removed conflicting box-shadow to avoid double outlines and improve visibility for keyboard users.